### PR TITLE
Tests, Link local, IPv6 and Performance

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -12,6 +12,8 @@ var PrivateNetworks = []string{
 	"172.16.0.0/12",
 	"169.254.0.0/16",
 	"192.168.0.0/16",
+	"fe80::/10",
+	"fd00::/8",
 }
 
 var privateNets []*net.IPNet

--- a/ip.go
+++ b/ip.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 )
 
-// Ranges of addresses allocated by IANA for private internets, as per RFC1918.
+// Ranges of addresses allocated by IANA for private internets, as per RFC1918 and RFC3927
+// for Link-local addresses.
 var PrivateNetworks = []string{
 	"10.0.0.0/8",
 	"172.16.0.0/12",
+	"169.254.0.0/16",
 	"192.168.0.0/16",
 }
 

--- a/ip.go
+++ b/ip.go
@@ -14,6 +14,18 @@ var PrivateNetworks = []string{
 	"192.168.0.0/16",
 }
 
+var privateNets []*net.IPNet
+
+func init() {
+	for _, network := range PrivateNetworks {
+		_, ipnet, err := net.ParseCIDR(network)
+		if err != nil {
+			panic(err)
+		}
+		privateNets = append(privateNets, ipnet)
+	}
+}
+
 // GetHostIPs returns a list of IP addresses of all host's interfaces.
 func GetHostIPs() ([]net.IP, error) {
 	ifaces, err := net.Interfaces()
@@ -61,8 +73,7 @@ func GetPrivateHostIPs() ([]net.IP, error) {
 
 // IsPrivate determines whether a passed IP address is from one of private blocks or not.
 func IsPrivate(ip net.IP) bool {
-	for _, network := range PrivateNetworks {
-		_, ipnet, _ := net.ParseCIDR(network)
+	for _, ipnet := range privateNets {
 		if ipnet.Contains(ip) {
 			return true
 		}

--- a/ip_test.go
+++ b/ip_test.go
@@ -1,0 +1,22 @@
+package iptools
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type IsPrivateSuite struct{}
+
+var _ = Suite(&IsPrivateSuite{})
+
+func (s *IsPrivateSuite) TestV4(c *C) {
+	c.Assert(IsPrivate(net.ParseIP("1.1.1.1")), Equals, false)
+
+	c.Assert(IsPrivate(net.ParseIP("10.0.0.1")), Equals, true)
+
+	c.Assert(IsPrivate(net.ParseIP("169.254.0.1")), Equals, true)
+}

--- a/ip_test.go
+++ b/ip_test.go
@@ -20,3 +20,11 @@ func (s *IsPrivateSuite) TestV4(c *C) {
 
 	c.Assert(IsPrivate(net.ParseIP("169.254.0.1")), Equals, true)
 }
+
+func (s *IsPrivateSuite) TestV6(c *C) {
+	c.Assert(IsPrivate(net.ParseIP("2607:f8b0:4000:802::200e")), Equals, false)
+
+	c.Assert(IsPrivate(net.ParseIP("fd12:3456:789a:1::1")), Equals, true)
+
+	c.Assert(IsPrivate(net.ParseIP("fe80::5054:8fff:fe9f:af62")), Equals, true)
+}


### PR DESCRIPTION
- [x] Adds test suite for `.IsPrivate()`
- [x] Treats link-local addresses as Private
- [x] Adds IPv6 support
- [x] Runs the `net.ParseCIDR` in `init()` function, to make the runtime IsPrivate faster & avoid allocations.

Sorry for one multi-purpose PR, but each commit is reviewable pretty separately, they just build on top of each other.